### PR TITLE
Cleaned up JS file and changed code to handle prefs change the same as button click when the page is loaded

### DIFF
--- a/app/js/script.js
+++ b/app/js/script.js
@@ -1,62 +1,58 @@
+
+/* 
+The first time the page is loaded, the color mode set on the preference 
+is used and set as 'default' in the local storage. 
+Changing the default preferences works the same way as changing the 
+color mode using the buttons, if the page is loaded.
+When the page is reloaded, whatever is the value set on the local storage
+has precedence over the values in the preference. If the preference
+changed after the page was visited - and the page is not loaded - 
+the last value saved on the local storage is loaded. 
+*/
+
 const darkButton = document.getElementById('dark');
 const lightButton = document.getElementById('light');
 
-const setColorMode = () => {
-  console.log('setColorMode');
-  console.log(localStorage.getItem('colorMode'));
-
-  if (localStorage.getItem('colorMode') == 'dark') {
-    setDarkMode();
-    darkButton.click();
-  } else if (localStorage.getItem('colorMode') == 'light') {
-    setLightMode();
-    lightButton.click();
-  }
-};
-
-const checkMode = () => {
-  if (localStorage.getItem('colorMode') == null) {
-    if (window.matchMedia('(prefers-color-scheme: light)').matches) {
-      lightButton.click();
-    } else if (window.matchMedia('(prefers-color-scheme: dark)').matches) {
-      darkButton.click();
-    }
-  }
-};
-
-const checkModeChange = () => {
-  window
-    .matchMedia('(prefers-color-scheme: dark)')
-    .addEventListener('change', (event) => {
-      console.log('checkModeChange');
-      checkMode();
-    });
-};
-
 const setDarkMode = () => {
-  console.log('setDarkMode');
   document.querySelector('body').classList = 'dark';
+  localStorage.setItem('colorMode', 'dark');
 };
 
 const setLightMode = () => {
-  console.log('setLightMode');
   document.querySelector('body').classList = 'light';
+  localStorage.setItem('colorMode', 'light');
 };
 
-setColorMode();
-checkMode();
-checkModeChange();
+const colorModeFromLocalStorage = () => {
+  return localStorage.getItem('colorMode');
+};
 
+const colorModeFromPreferences = () => {
+  return window.matchMedia('(prefers-color-scheme: dark)').matches 
+              ? 'dark'
+              : 'light' // If preference is set or does not match anything (light is default)
+};
+
+const loadAndUpdateColor = () => {
+  // local storage has precendence over the prefers-color-scheme
+  const color = colorModeFromLocalStorage() || colorModeFromPreferences();
+  color == 'dark' ? darkButton.click() : lightButton.click();
+};
+
+// when the inputs are clicked, check which radio button is checked and change the color
 const radioButtons = document.querySelectorAll('.toggle__wrapper input');
-for (let i = 0; i < radioButtons.length; i++) {
-  radioButtons[i].addEventListener('click', (event) => {
-    console.log('radio button clicked');
-    if (darkButton.checked) {
-      localStorage.setItem('colorMode', 'dark');
-      setDarkMode();
-    } else {
-      localStorage.setItem('colorMode', 'light');
-      setLightMode();
-    }
+radioButtons.forEach(button => {
+  button.addEventListener('click', (event) => {
+    darkButton.checked ? setDarkMode() : setLightMode();
   });
-}
+});
+
+// when the prefers-color-scheme changes, this event will be emitted
+// event reflects the media query, if it matches, the new color is dark, else it is light
+window.matchMedia('(prefers-color-scheme: dark)')
+      .addEventListener('change', (event) => {
+        event.matches ? darkButton.click() : lightButton.click();
+      });
+      
+// Load the right color on startup - localStorage has precedence
+loadAndUpdateColor();


### PR DESCRIPTION
I noticed the JS code was too convoluted, so I decided to clean it up a little bit and add some more comments. I also noticed that the behavior on the page wasn't consistent when the theme preference would change while the page was loaded.

In this small change, besides the clean up, the page will adjust to the new preferred color when it changes as if the the radio button were used. If the preference changes after the page was loaded and closed, then whatever was saved on the local storage wins. If the local storage is emptied, then the color preference win or the color defaults to light.